### PR TITLE
Create sessions in IMDS response for static keypair profiles

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,4 @@
+# imds-credential-server contributors
+
+* [Ben Kehoe](https://github.com/benkehoe)
+* [Barrett Weisshaar](https://github.com/ravenium)

--- a/main.go
+++ b/main.go
@@ -245,30 +245,59 @@ func (cfg *Config) handleCredentialRequest(w http.ResponseWriter, req *http.Requ
 		writeError(w, http.StatusInternalServerError, "InternalServerError", "Something went wrong")
 		return
 	}
-	creds := Credentials{
-		AccessKeyId:     awsCreds.AccessKeyID,
-		SecretAccessKey: awsCreds.SecretAccessKey,
-	}
-	if awsCreds.SessionToken != "" {
-		creds.Token = awsCreds.SessionToken
-	}
-	if !awsCreds.Expires.IsZero() {
-		expiration, err := awsCreds.Expires.MarshalText()
+	creds := Credentials{}
+	if awsCreds.SessionToken == "" {
+		// If we have static credentials, the SDK doesn't know what to do if it sees
+		// static keypairs in IMDS.  Get a session token with our static keypair, and
+		// return it.
+		stsClient := sts.NewFromConfig(cfg.AwsConfig)
+		sessionCreds, err := stsClient.GetSessionToken(context.TODO(), &sts.GetSessionTokenInput{})
 		if err != nil {
 			log.Println(err)
 			writeError(w, http.StatusInternalServerError, "InternalServerError", "Something went wrong")
 			return
 		}
-		creds.Expiration = string(expiration)
+		// Expiration has a method of .String() but it returns it in a format awscli doesn't understand.
+
+		sessionExpiration, err := sessionCreds.Credentials.Expiration.MarshalText()
+		if err != nil {
+			log.Println(err)
+			writeError(w, http.StatusInternalServerError, "InternalServerError", "Something went wrong")
+			return
+		}
+
+		creds = Credentials{
+			AccessKeyId:     *sessionCreds.Credentials.AccessKeyId,
+			SecretAccessKey: *sessionCreds.Credentials.SecretAccessKey,
+			Token:           *sessionCreds.Credentials.SessionToken,
+			Expiration:      string(sessionExpiration),
+		}
+
 	} else {
-		expirationTime := time.Now().Add(time.Hour)
-		expiration, err := expirationTime.MarshalText()
-		if err != nil {
-			log.Println(err)
-			writeError(w, http.StatusInternalServerError, "InternalServerError", "Something went wrong")
-			return
+		// We have a standard session, proceed as normal
+		creds = Credentials{
+			AccessKeyId:     awsCreds.AccessKeyID,
+			SecretAccessKey: awsCreds.SecretAccessKey,
+			Token:           awsCreds.SessionToken,
 		}
-		creds.Expiration = string(expiration)
+		if !awsCreds.Expires.IsZero() {
+			expiration, err := awsCreds.Expires.MarshalText()
+			if err != nil {
+				log.Println(err)
+				writeError(w, http.StatusInternalServerError, "InternalServerError", "Something went wrong")
+				return
+			}
+			creds.Expiration = string(expiration)
+		} else {
+			expirationTime := time.Now().Add(time.Hour)
+			expiration, err := expirationTime.MarshalText()
+			if err != nil {
+				log.Println(err)
+				writeError(w, http.StatusInternalServerError, "InternalServerError", "Something went wrong")
+				return
+			}
+			creds.Expiration = string(expiration)
+		}
 	}
 
 	bodyBytes, err := json.Marshal(creds)


### PR DESCRIPTION
When using imds with a static AWS keypair, the aws cli doesn't understand what to do with it when it appears via the metadata service.  For example, let's say you have a static key ID/secret in a profile in aws-vault and use it to launch the credential server like so:

`aws-vault exec --no-session myprofile -- ./imds-credential-server`

This normally would say "directly pass the keypair so I don't have an expiration".

The app itself doesn't complain because it can read the Principal just fine, but when it returns the keypair in metadata, sdk/cli clients return "no credentials found" because they don't expect to see anything other than a valid session in there.

This change (apologies for my mediocre Go) looks to see if there's a sessiontoken missing and if so, spins up a session to get one.

Why do this, you might ask, vs just having aws/aws-vault handle session generation, e.g.:

`aws-vault exec myprofile -- ./imds-credential-server`
or
`./imds-credential-server --profile myprofile`
or otherwise?

The basic reason is that while I want to keep credentials off disk (and out of the .aws/credentials file!), I can't eliminate the need for longer lived keypairs just yet.  This means storing credentials in things like aws-vault and 1Password.

1Password in particular is of note because it leverages credential_helper, and unlike aws-vault it typically gets configured for static credentials.

Let me know what you think!