### PR TITLE
fix: Make server compliant with Go SDK V2

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,3 +2,4 @@
 
 * [Ben Kehoe](https://github.com/benkehoe)
 * [Barrett Weisshaar](https://github.com/ravenium)
+* [Ben Bernays](https://github.com/bbernays)

--- a/main.go
+++ b/main.go
@@ -196,7 +196,7 @@ func (cfg *Config) handleTokenRequest(w http.ResponseWriter, req *http.Request) 
 	ttl := time.Second * time.Duration(ttlInt)
 
 	bodyBytes := cfg.EncodeToken(ttl)
-
+	w.Header().Add("X-aws-ec2-metadata-token-ttl-seconds", ttlStr)
 	w.Header().Add("Content-type", "text/plain")
 	w.Write(bodyBytes)
 }
@@ -236,6 +236,7 @@ type Credentials struct {
 	SecretAccessKey string
 	Token           string
 	Expiration      string
+	Code            string
 }
 
 func getTemporaryCredentials(awsConfig aws.Config) (Credentials, error) {
@@ -258,6 +259,7 @@ func getTemporaryCredentials(awsConfig aws.Config) (Credentials, error) {
 		SecretAccessKey: *sessionCreds.Credentials.SecretAccessKey,
 		Token:           *sessionCreds.Credentials.SessionToken,
 		Expiration:      string(sessionExpiration),
+		Code:            "Success",
 	}
 
 	return creds, nil
@@ -295,6 +297,7 @@ func (cfg *Config) GetCredentials() (Credentials, error) {
 		SecretAccessKey: awsCreds.SecretAccessKey,
 		Token:           awsCreds.SessionToken,
 		Expiration:      string(expiration),
+		Code:            "Success",
 	}
 
 	return creds, nil

--- a/main.go
+++ b/main.go
@@ -306,6 +306,7 @@ func (cfg *Config) GetCredentials() (Credentials, error) {
 		Expiration:      string(expiration),
 		LastUpdated:     time.Now().UTC().String(),
 		Code:            "Success",
+		Type:            "AWS-HMAC",
 	}
 
 	return creds, nil

--- a/main.go
+++ b/main.go
@@ -233,7 +233,7 @@ func (cfg *Config) handleRoleRequest(w http.ResponseWriter, req *http.Request) {
 	io.WriteString(w, cfg.PrincipalName)
 }
 
-type Credentials struct {
+type Response struct {
 	AccessKeyId     string
 	SecretAccessKey string
 	Token           string
@@ -245,8 +245,8 @@ type Credentials struct {
 	Type        string
 }
 
-func getTemporaryCredentials(awsConfig aws.Config) (Credentials, error) {
-	creds := Credentials{}
+func getTemporaryCredentials(awsConfig aws.Config) (Response, error) {
+	creds := Response{}
 	stsClient := sts.NewFromConfig(awsConfig)
 	sessionCreds, err := stsClient.GetSessionToken(context.TODO(), &sts.GetSessionTokenInput{})
 	if err != nil {
@@ -259,7 +259,7 @@ func getTemporaryCredentials(awsConfig aws.Config) (Credentials, error) {
 		return creds, err
 	}
 
-	creds = Credentials{
+	creds = Response{
 		AccessKeyId:     *sessionCreds.Credentials.AccessKeyId,
 		SecretAccessKey: *sessionCreds.Credentials.SecretAccessKey,
 		Token:           *sessionCreds.Credentials.SessionToken,
@@ -272,8 +272,8 @@ func getTemporaryCredentials(awsConfig aws.Config) (Credentials, error) {
 	return creds, nil
 }
 
-func (cfg *Config) GetCredentials() (Credentials, error) {
-	creds := Credentials{}
+func (cfg *Config) GetCredentials() (Response, error) {
+	creds := Response{}
 	awsCreds, err := cfg.AwsConfig.Credentials.Retrieve(context.TODO())
 	if err != nil {
 		return creds, err
@@ -299,7 +299,7 @@ func (cfg *Config) GetCredentials() (Credentials, error) {
 		return creds, err
 	}
 
-	creds = Credentials{
+	creds = Response{
 		AccessKeyId:     awsCreds.AccessKeyID,
 		SecretAccessKey: awsCreds.SecretAccessKey,
 		Token:           awsCreds.SessionToken,


### PR DESCRIPTION
Closes: #3 

The Go SDK V2 I think has more validation than other SDKs. This PR adds in the few headers/response codes required to get it working. 

If there is anything else that is needed for this to be approved and released please let me know!