### PR TITLE
Support .NET Framework on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 imds-credential-server
+imds-credential-server.exe

--- a/main.go
+++ b/main.go
@@ -219,7 +219,7 @@ func (cfg *Config) handleRequest(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if req.URL.Path == "/latest/meta-data/iam/security-credentials/" {
+	if strings.TrimSuffix(req.URL.Path, "/") == "/latest/meta-data/iam/security-credentials" {
 		cfg.handleRoleRequest(w, req)
 		return
 	} else {
@@ -354,7 +354,7 @@ func (cfg *Config) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	log.Println(req.Method, req.URL.Path)
 	if req.URL.Path == "/latest/api/token" {
 		cfg.handleTokenRequest(w, req)
-	} else if strings.HasPrefix(req.URL.Path, "/latest/meta-data/iam/security-credentials/") {
+	} else if strings.HasPrefix(req.URL.Path, "/latest/meta-data/iam/security-credentials") {
 		cfg.handleRequest(w, req)
 	} else {
 		writeError(w, http.StatusNotFound, "InvalidPath", "Invalid path")


### PR DESCRIPTION
AWS SDK for .NET Framework calls `/latest/meta-data/iam/security-credentials`, but the server code is listening for `/latest/meta-data/iam/security-credentials/`.

## Given

* A .NET Framework project

## Before
```
❯ .\imds-credential-server.exe --profile myprofile --port 12345
Identity: arn:aws:sts::123456789012:assumed-role/AWSReservedSSO_myrole_abc123/myemail@example.com
2024/09/16 10:57:42 PUT /latest/api/token
2024/09/16 10:57:42 GET /latest/meta-data/iam/security-credentials
2024/09/16 10:57:42 PUT /latest/api/token
2024/09/16 10:57:42 GET /latest/meta-data/iam/security-credentials
2024/09/16 10:57:42 GET /latest/meta-data/iam/security-credentials
2024/09/16 10:57:42 GET /latest/meta-data/iam/security-credentials
2024/09/16 10:57:43 GET /latest/meta-data/iam/security-credentials
2024/09/16 10:57:43 GET /latest/meta-data/iam/security-credentials
```

## After
```
> .\imds-credential-server.exe --profile myprofile --port 12345
Identity: arn:aws:sts::123456789012:assumed-role/AWSReservedSSO_myrole_abc123/myemail@example.com
2024/09/16 10:54:14 PUT /latest/api/token
2024/09/16 10:54:14 GET /latest/meta-data/iam/security-credentials
2024/09/16 10:54:14 PUT /latest/api/token
2024/09/16 10:54:14 GET /latest/meta-data/iam/security-credentials/AWSReservedSSO_myrole_abc123
```

## Compare
Compare with the logs for AWS CLI requests

```
> .\imds-credential-server.exe --profile myprofile --port 12345
Identity: arn:aws:sts::123456789012:assumed-role/AWSReservedSSO_myrole_abc123/myemail@example.com
2024/09/16 10:59:36 PUT /latest/api/token
2024/09/16 10:59:36 GET /latest/meta-data/placement/availability-zone/
2024/09/16 10:59:36 PUT /latest/api/token
2024/09/16 10:59:36 GET /latest/meta-data/iam/security-credentials/
2024/09/16 10:59:36 GET /latest/meta-data/iam/security-credentials/AWSReservedSSO_myrole_abc123
```
